### PR TITLE
a few additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,96 +5,53 @@
 
 **Get started**
 ```
-bun lint.ts
+bun lint.ts ./replay.cc
+# or
+npx ts-node lint.ts ./replay.cc
 ```
+
 
 **Errors**
 Running the script will output these errors which might be legitimate.
 
 ```
-[
+Script gReplayScript:
+ [
   {
-    ruleId: "no-undef",
-    severity: 2,
-    message: "'frames' is not defined.",
-    line: 976,
-    column: 66,
-    nodeType: "Identifier",
-    messageId: "undef",
-    endLine: 976,
-    endColumn: 72
-  }, {
-    ruleId: "no-undef",
+    ruleId: 'no-unused-vars',
+    severity: 1,
+    message: "'logTrace' is defined but never used. Allowed unused vars must match /^_/u.",
+    line: 228,
+    column: 10,
+    nodeType: 'Identifier',
+    messageId: 'unusedVar',
+    endLine: 228,
+    endColumn: 18
+  },
+  {
+    ruleId: 'no-unused-vars',
+    severity: 1,
+    message: "'isNonNullObject' is defined but never used. Allowed unused vars must match /^_/u.",
+    line: 981,
+    column: 10,
+    nodeType: 'Identifier',
+    messageId: 'unusedVar',
+    endLine: 981,
+    endColumn: 25
+  },
+...
+  {
+    ruleId: 'no-undef',
     severity: 2,
     message: "'frameIndex' is not defined.",
-    line: 979,
+    line: 1141,
     column: 29,
-    nodeType: "Identifier",
-    messageId: "undef",
-    endLine: 979,
+    nodeType: 'Identifier',
+    messageId: 'undef',
+    endLine: 1141,
     endColumn: 39
-  }, {
-    ruleId: "no-undef",
-    severity: 2,
-    message: "'getObjectIdRaw' is not defined.",
-    line: 1511,
-    column: 13,
-    nodeType: "Identifier",
-    messageId: "undef",
-    endLine: 1511,
-    endColumn: 27
-  }, {
-    ruleId: "no-undef",
-    severity: 2,
-    message: "'styleInfo' is not defined.",
-    line: 2054,
-    column: 5,
-    nodeType: "Identifier",
-    messageId: "undef",
-    endLine: 2054,
-    endColumn: 14
-  }, {
-    ruleId: "no-undef",
-    severity: 2,
-    message: "'styleInfo' is not defined.",
-    line: 2055,
-    column: 25,
-    nodeType: "Identifier",
-    messageId: "undef",
-    endLine: 2055,
-    endColumn: 34
-  }, {
-    ruleId: "no-undef",
-    severity: 2,
-    message: "'styleInfo' is not defined.",
-    line: 2057,
-    column: 15,
-    nodeType: "Identifier",
-    messageId: "undef",
-    endLine: 2057,
-    endColumn: 24
-  }, {
-    ruleId: "no-undef",
-    severity: 2,
-    message: "'styleInfo' is not defined.",
-    line: 2058,
-    column: 16,
-    nodeType: "Identifier",
-    messageId: "undef",
-    endLine: 2058,
-    endColumn: 25
-  }, {
-    ruleId: "no-undef",
-    severity: 2,
-    message: "'styleInfo' is not defined.",
-    line: 2058,
-    column: 43,
-    nodeType: "Identifier",
-    messageId: "undef",
-    endLine: 2058,
-    endColumn: 52
-  }
-]
-ESLint issue
-ESLint issue
+  },
+...
+ ]
+ESLint: 12 errors, 18 warnings
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,11 @@
 {
-  "name": "Jan-04",
+  "name": "lint-cc",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "dependencies": {
+        "@types/eslint": "^8.56.1",
         "eslint": "^8.56.0"
       }
     },
@@ -129,6 +130,25 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@types/eslint": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.1.tgz",
+      "integrity": "sha512-18PLWRzhy9glDQp3+wOgfLYRWlhgX0azxgJ63rdpoUHyrC9z0f5CkFburjQx4uD7ZCruw85ZtMt6K+L+R8fLJQ==",
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,9 @@
 {
+  "scripts": {
+    "test": "npx ts-node ./lint.ts ./replay.cc"
+  },
   "dependencies": {
+    "@types/eslint": "^8.56.1",
     "eslint": "^8.56.0"
   }
 }


### PR DESCRIPTION
A couple of changes/additions:
    
1. process all text blocks and print out warnings/errors from all of them.  add their name to the output.
2. Add `no-unused-vars` to the linter config (with ignore patterns).
3. keep a count of both errors/warnings and set exit status based on error count > 0.
4. accept file path on the command line.
5. add "npm test" support
